### PR TITLE
feat(menu): restructure menu logic for dynamic categories, cropping and image previews

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -54,7 +54,12 @@
 
   "menuPage": {
     "title": "Menu",
-    "description": "Our small but mighty rotating menu. Subject to availability!"
+    "description": "Our small but mighty rotating menu. Subject to availability!",
+    "categories": {
+      "BBQ Meats": "BBQ Meats",
+      "Sides": "Sides",
+      "Fixins": "Fixins"
+    }
   },
 
   "merchPage": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -54,7 +54,12 @@
 
   "menuPage": {
     "title": "Menú",
-    "description": "Nuestro menú rotativo es pequeño pero poderoso. ¡Sujeto a disponibilidad!"
+    "description": "Nuestro menú rotativo es pequeño pero poderoso. ¡Sujeto a disponibilidad!",
+    "categories": {
+      "BBQ Meats": "Carnes BBQ",
+      "Sides": "Acompañamientos",
+      "Fixins": "Complementos"
+    }
   },
 
   "merchPage": {

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -2,21 +2,15 @@
 
 import { useTranslation } from 'react-i18next'
 import { useEffect, useState } from 'react'
-import { fetchMenuItems } from '@/utils/menuService'
+import { fetchMenuItems, MenuItemData, MenuCategory } from '@/utils/menuService'
 import Image from 'next/image'
+
+const CATEGORIES: MenuCategory[] = ['BBQ Meats', 'Sides', 'Fixins']
 
 export default function MenuPage() {
   const { t, i18n } = useTranslation()
   const [mounted, setMounted] = useState(false)
-  const [items, setItems] = useState<
-    {
-      id: string
-      en: { title: string; description: string }
-      es: { title: string; description: string }
-      images: string[]
-      activeImage: string
-    }[]
-  >([])
+  const [items, setItems] = useState<(MenuItemData & { id: string })[]>([])
 
   useEffect(() => {
     setMounted(true)
@@ -37,27 +31,43 @@ export default function MenuPage() {
         <h1 className="text-4xl font-bold text-pink-500 mb-4">{t('menuPage.title')}</h1>
         <p className="text-white/70 mb-12">{t('menuPage.description')}</p>
 
-        <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
-          {items.map((item) => (
-            <div
-              key={item.id}
-              className="bg-zinc-900 p-6 rounded-xl border border-white/10 hover:border-pink-400 transition-all hover:shadow-lg"
-            >
-              {item.activeImage && (
-                <div className="relative w-full h-48 mb-4">
-                  <Image
-                    src={item.activeImage}
-                    alt={item[lang].title}
-                    fill
-                    className="object-cover rounded"
-                  />
-                </div>
-              )}
-              <h2 className="text-xl font-bold text-pink-400 mb-2">{item[lang].title}</h2>
-              <p className="text-white/80 text-sm mb-3">{item[lang].description}</p>
+        {CATEGORIES.map((category) => {
+          const categoryItems = items
+            .filter((item) => item.category === category)
+            .sort((a, b) => a.order - b.order)
+
+          if (categoryItems.length === 0) return null
+
+          return (
+            <div key={category} className="mb-12 text-left">
+              <h2 className="text-2xl font-bold text-pink-400 mb-6">
+                {t(`menuPage.categories.${category}`)}
+              </h2>
+
+              <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+                {categoryItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className="bg-zinc-900 p-6 rounded-xl border border-white/10 hover:border-pink-400 transition-all hover:shadow-lg"
+                  >
+                    {item.activeImage && (
+                      <div className="relative w-full h-48 mb-4">
+                        <Image
+                          src={item.activeImage}
+                          alt={item[lang].title}
+                          fill
+                          className="object-cover rounded"
+                        />
+                      </div>
+                    )}
+                    <h3 className="text-xl font-bold text-pink-400 mb-2">{item[lang].title}</h3>
+                    <p className="text-white/80 text-sm mb-3">{item[lang].description}</p>
+                  </div>
+                ))}
+              </div>
             </div>
-          ))}
-        </div>
+          )
+        })}
       </section>
     </main>
   )

--- a/src/utils/menuService.ts
+++ b/src/utils/menuService.ts
@@ -1,6 +1,19 @@
-import { collection, addDoc, getDocs, updateDoc, deleteDoc, doc } from 'firebase/firestore'
+import {
+  collection,
+  addDoc,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+  doc,
+  query,
+  orderBy,
+  writeBatch,
+} from 'firebase/firestore'
 import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage'
 import { db } from '@/firebase/config'
+import { v4 as uuidv4 } from 'uuid'
+
+export type MenuCategory = 'BBQ Meats' | 'Sides' | 'Fixins'
 
 export interface MenuLocale {
   title: string
@@ -8,17 +21,20 @@ export interface MenuLocale {
 }
 
 export interface MenuItemData {
+  category: MenuCategory
   en: MenuLocale
   es: MenuLocale
   images: string[]
   activeImage: string
+  order: number
 }
 
 const collectionRef = collection(db, 'menuItems')
 
-// Fetch all menu items
+// Fetch all menu items, ordered by the order field
 export async function fetchMenuItems(): Promise<(MenuItemData & { id: string })[]> {
-  const snapshot = await getDocs(collectionRef)
+  const q = query(collectionRef, orderBy('order'))
+  const snapshot = await getDocs(q)
   return snapshot.docs.map(
     (doc) => ({ id: doc.id, ...doc.data() }) as MenuItemData & { id: string }
   )
@@ -29,7 +45,7 @@ export async function addMenuItem(data: MenuItemData): Promise<void> {
   await addDoc(collectionRef, data)
 }
 
-// Update an existing item
+// Update an existing menu item
 export async function updateMenuItem(id: string, data: Partial<MenuItemData>): Promise<void> {
   await updateDoc(doc(collectionRef, id), data)
 }
@@ -39,10 +55,21 @@ export async function deleteMenuItem(id: string): Promise<void> {
   await deleteDoc(doc(collectionRef, id))
 }
 
-// Upload image and return URL
+// Upload image and return its download URL
 export async function uploadMenuImage(file: File): Promise<string> {
   const storage = getStorage()
-  const fileRef = ref(storage, `menu/${file.name}`)
+  const uniqueName = `${uuidv4()}-${file.name}`
+  const fileRef = ref(storage, `menu/${uniqueName}`)
   await uploadBytes(fileRef, file)
   return await getDownloadURL(fileRef)
+}
+
+// Update the order of all menu items after drag and drop
+export async function updateMenuOrder(items: (MenuItemData & { id: string })[]): Promise<void> {
+  const batch = writeBatch(db)
+  items.forEach((item, index) => {
+    const itemRef = doc(collectionRef, item.id)
+    batch.update(itemRef, { order: index })
+  })
+  await batch.commit()
 }


### PR DESCRIPTION
- Updated menuService.ts to generate unique image names using uuid for consistent Firebase uploads
- Reorganized admin menu page
  - Added support for separate file, croppedFile, and preview state
  - Improved flow to allow image selection and cropping before entering text
- Added detailed admin instructions on how to add and manage menu items
- Updated frontend menu to group items by category and display translations
- Fixed i18n translation structure in en/translation.json and es/translation.json to correctly show category headings in both languages