### PR TITLE
feat: improve banner admin logic with crop, preview, and active state enforcement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,8 +33,10 @@ export default function Home() {
     imageUrl: string
     altText: string
     subtitle: string
-    title: string
+    title?: string
+    shape?: 'square' | 'rect'
   } | null>(null)
+  
 
   useEffect(() => {
     setMounted(true)
@@ -81,18 +83,24 @@ export default function Home() {
         {/* Dynamic Banner Image */}
         {banner && (
           <>
-            <div className="w-[400px] h-[400px] mx-auto border border-white/10 rounded-lg shadow overflow-hidden">
+            <div
+              className={`mx-auto border border-white/10 rounded-lg shadow overflow-hidden ${
+                banner.shape === 'rect'
+                  ? 'w-[600px] h-[300px]'
+                  : 'w-[400px] h-[400px]'
+              }`}
+            >
               <Image
                 src={banner.imageUrl}
                 alt={banner.altText}
-                width={400}
-                height={400}
+                width={banner.shape === 'rect' ? 600 : 400}
+                height={banner.shape === 'rect' ? 300 : 400}
                 className="w-full h-full object-contain"
                 priority
               />
             </div>
 
-            <p className="text-xl max-w-xl text-white/80">{banner.subtitle}</p>
+            <p className="text-xl max-w-xl text-white/80 mt-4">{banner.subtitle}</p>
           </>
         )}
       </motion.section>

--- a/src/utils/firebaseService.ts
+++ b/src/utils/firebaseService.ts
@@ -14,15 +14,34 @@ export async function fetchHomepageBanner(locale: 'en' | 'es') {
   if (!bannerSnap.exists()) return null
 
   const data = bannerSnap.data()
-  return data[locale]
+
+  return {
+    imageUrl: data[locale]?.imageUrl || '',
+    subtitle: data[locale]?.subtitle || '',
+    altText: data[locale]?.altText || '',
+    shape: data.shape || 'square', // fallback
+  }
 }
 
 export async function updateBannerContent(
   bannerId: string,
-  updatedFields: Partial<{ subtitle: string; altText: string }>
+  updatedFields: Partial<{ subtitle: string; altText: string; shape: 'square' | 'rect' }>
 ) {
-  await updateDoc(doc(db, 'banners', bannerId), {
-    en: updatedFields,
-    es: updatedFields,
-  })
+  const updates: Record<string, string> = {}
+
+  if ('subtitle' in updatedFields) {
+    updates['en.subtitle'] = updatedFields.subtitle || ''
+    updates['es.subtitle'] = updatedFields.subtitle || ''
+  }
+
+  if ('altText' in updatedFields) {
+    updates['en.altText'] = updatedFields.altText || ''
+    updates['es.altText'] = updatedFields.altText || ''
+  }
+
+  if ('shape' in updatedFields && updatedFields.shape) {
+    updates['shape'] = updatedFields.shape
+  }
+
+  await updateDoc(doc(db, 'banners', bannerId), updates)
 }


### PR DESCRIPTION
- Removed most hardcoded banner logic in favor of Firestore-based banners
- Added support for cropping banners (square or rectangle) with preview before upload
- Enforced requirement that one banner must always be active
- Updated frontend to dynamically render banners by shape and content